### PR TITLE
Add interpreter for init file

### DIFF
--- a/cyclotron-svc/init.d/cyclotron-svc
+++ b/cyclotron-svc/init.d/cyclotron-svc
@@ -1,3 +1,4 @@
+#! /bin/bash
 #
 # Cyclotron-svc daemon script
 # chkconfig: 2345 50 50


### PR DESCRIPTION
Just trying to make it work on rhel 7 get rid of 
Failed at step EXEC spawning /etc/rc.d/init.d/cyclotron-svc: Exec format error