### PR TITLE
Add optional configuration for cacheEncryptedPassword

### DIFF
--- a/cyclotron-site/app/scripts/common/services/services.cryptoService.coffee
+++ b/cyclotron-site/app/scripts/common/services/services.cryptoService.coffee
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2013-2015 the original author or authors.
+# Copyright (c) 2013-2017 the original author or authors.
 #
 # Licensed under the MIT License (the "License");
 # you may not use this file except in compliance with the License. 

--- a/cyclotron-site/app/scripts/common/services/services.userService.coffee
+++ b/cyclotron-site/app/scripts/common/services/services.userService.coffee
@@ -14,7 +14,7 @@
 # language governing permissions and limitations under the License. 
 ###
 
-cyclotronServices.factory 'userService', ($http, $localForage, $q, $rootScope, $window, configService, logService) ->
+cyclotronServices.factory 'userService', ($http, $localForage, $q, $rootScope, $window, configService, cryptoService, logService) ->
 
     loggedIn = false
     currentSession = null
@@ -25,6 +25,8 @@ cyclotronServices.factory 'userService', ($http, $localForage, $q, $rootScope, $
         cachedUserId: null
 
         cachedUsername: null
+
+        cachedPassword: null
 
         isLoggedIn: -> 
             return true unless configService.authentication.enable
@@ -39,6 +41,15 @@ cyclotronServices.factory 'userService', ($http, $localForage, $q, $rootScope, $
         setLoggedOut: ->
             loggedIn = false
             currentSession = null
+            exports.cachedPassword = null
+            $localForage.removeItem('session')
+            $localForage.removeItem('cachedPassword')
+
+            if $window.Cyclotron?
+                $window.Cyclotron.currentUser = null
+                $window.Cyclotron.currentUserPassword = null
+                
+            return
 
         isNewUser: true
 
@@ -62,6 +73,13 @@ cyclotronServices.factory 'userService', ($http, $localForage, $q, $rootScope, $
     $localForage.getItem('cachedUserId').then (userId) ->
         if userId?
             exports.cachedUserId = userId
+
+    # Load cached user password (encrypted)
+    $localForage.getItem('cachedPassword').then (cachedPassword) ->
+        if cachedPassword? and configService.authentication.cacheEncryptedPassword
+            exports.cachedPassword = cachedPassword
+            if $window.Cyclotron?
+                $window.Cyclotron.currentUserPassword = cachedPassword
 
     # Load New User quality
     $localForage.getItem('newUser').then (value) ->
@@ -97,9 +115,22 @@ cyclotronServices.factory 'userService', ($http, $localForage, $q, $rootScope, $
             $rootScope.$broadcast 'login', { }
             if $window.Cyclotron?
                 $window.Cyclotron.currentUser = session.user
+            
             alertify.success('Logged in as <strong>' + session.user.name + '</strong>', 2500)
 
-            deferred.resolve(session)
+            if (configService.authentication.cacheEncryptedPassword)
+                # Encrypt and cache the password for use in data sources
+                cryptoService.encrypt(password).then (encrypedPassword) ->
+                    $localForage.setItem 'cachedPassword', encrypedPassword
+                    exports.cachedPassword = encrypedPassword
+                    if $window.Cyclotron?
+                        $window.Cyclotron.currentUserPassword = encrypedPassword
+
+                    deferred.resolve(session)
+            else 
+                
+                deferred.resolve(session)
+            
 
         post.error (error) ->
             exports.setLoggedOut()
@@ -124,12 +155,14 @@ cyclotronServices.factory 'userService', ($http, $localForage, $q, $rootScope, $
                     validator.success (session) ->
                         currentSession = session
                         loggedIn = true
+                        if $window.Cyclotron?
+                            $window.Cyclotron.currentUser = session.user
 
                         alertify.log('Logged in as <strong>' + session.user.name + '</strong>', 2500) unless hideAlerts
                         deferred.resolve(session)
 
                     validator.error (error) ->
-                        $localForage.removeItem('session')
+                        exports.setLoggedOut()
                         alertify.log('Previous session expired', 2500) unless hideAlerts
                         errorHandler()
                 else
@@ -147,11 +180,8 @@ cyclotronServices.factory 'userService', ($http, $localForage, $q, $rootScope, $
             promise = $http.post(configService.restServiceUrl + '/users/logout', { key: currentSession.key })
             promise.success ->
                 exports.setLoggedOut()
-                $localForage.removeItem('session')
                 
                 $rootScope.$broadcast('logout')
-                if $window.Cyclotron?
-                    $window.Cyclotron.currentUser = null
                 alertify.log('Logged Out', 2500)
                 deferred.resolve()
 

--- a/cyclotron-site/app/scripts/config/sample.configService.coffee
+++ b/cyclotron-site/app/scripts/config/sample.configService.coffee
@@ -61,6 +61,10 @@ cyclotronServices.factory 'configService', (commonConfigService) ->
             # Message displayed when logging in.  Set to null/blank to disable
             loginMessage: 'Please login using your LDAP username and password.'
 
+            # If true, the user's password will be encrypted and cached in the browser
+            # This allows data sources to authenticate with the current user's credentials
+            cacheEncryptedPassword: false
+
         # Analytics settings
         analytics:
             # Enable or disable analytic tracking for dashboards

--- a/cyclotron-site/app/scripts/dashboards/controller.dashboard.coffee
+++ b/cyclotron-site/app/scripts/dashboards/controller.dashboard.coffee
@@ -46,6 +46,7 @@ cyclotronApp.controller 'DashboardController', ($scope, $stateParams, $localFora
     $window.Cyclotron =
         version: configService.version
         currentUser: userService.currentUser()
+        currentUserPassword: userService.cachedPassword
         dataSources: {}
         functions: 
             forceUpdate: -> $scope.$apply()


### PR DESCRIPTION
Add optional setting that stores the user's encrypted password in memory after logging in, allowing Data Sources to authenticate using the credentials of the current user, rather than a hardcoded account.

This is disabled by default.